### PR TITLE
Initialize phtread_attr_t structure

### DIFF
--- a/www/chromium/files/patch-third_party__WebKit__Source__heap__ThreadState.cpp
+++ b/www/chromium/files/patch-third_party__WebKit__Source__heap__ThreadState.cpp
@@ -1,6 +1,6 @@
 --- ./third_party/WebKit/Source/heap/ThreadState.cpp.orig	2014-04-24 22:39:56.000000000 +0200
 +++ ./third_party/WebKit/Source/heap/ThreadState.cpp	2014-04-24 23:23:47.000000000 +0200
-@@ -43,13 +43,21 @@
+@@ -43,13 +43,22 @@
  extern "C" void* __libc_stack_end;  // NOLINT
  #endif
  
@@ -16,6 +16,7 @@
 +#if defined(__GLIBC__) || OS(ANDROID) || OS(FREEBSD)
      pthread_attr_t attr;
 +#if OS(FREEBSD)
++    pthread_attr_init(&attr);
 +    if (!pthread_attr_get_np(pthread_self(), &attr)) {
 +#else
      if (!pthread_getattr_np(pthread_self(), &attr)) {
@@ -23,3 +24,13 @@
          void* base;
          size_t size;
          int error = pthread_attr_getstack(&attr, &base, &size);
+@@ -57,6 +66,9 @@
+         pthread_attr_destroy(&attr);
+         return reinterpret_cast<Address>(base) + size;
+     }
++#if OS(FREEBSD)
++    pthread_attr_destroy(&attr);
++#endif
+ #if defined(__GLIBC__)
+     // pthread_getattr_np can fail for the main thread. In this case
+     // just like NaCl we rely on the __libc_stack_end to give us


### PR DESCRIPTION
FreeBSD 10.0 man page for pthread_attr_get_np(3) highly recommends to initialize the structure before calling the function. Indeed, without initialization, Chromium Content Framework (cef) based on 35.0.1916.27 crashes.

http://www.freebsd.org/cgi/man.cgi?query=pthread_attr_get_np
