### PR TITLE
Fix settings page, by taking VideoCaptureDevice patches from OpenBSD.

### DIFF
--- a/www/chromium/files/patch-media__video__capture__fake_video_capture_device_factory.cc
+++ b/www/chromium/files/patch-media__video__capture__fake_video_capture_device_factory.cc
@@ -1,0 +1,11 @@
+--- media/video/capture/fake_video_capture_device_factory.cc.orig	2015-06-19 21:21:37 UTC
++++ media/video/capture/fake_video_capture_device_factory.cc
+@@ -48,7 +48,7 @@
+   for (int n = 0; n < number_of_devices_; ++n) {
+     VideoCaptureDevice::Name name(base::StringPrintf("fake_device_%d", n),
+                                   base::StringPrintf("/dev/video%d", n)
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+                                   , VideoCaptureDevice::Name::V4L2_SINGLE_PLANE
+ #elif defined(OS_MACOSX)
+                                   , VideoCaptureDevice::Name::AVFOUNDATION

--- a/www/chromium/files/patch-media__video__capture__file_video_capture_device_factory.cc
+++ b/www/chromium/files/patch-media__video__capture__file_video_capture_device_factory.cc
@@ -1,0 +1,11 @@
+--- media/video/capture/file_video_capture_device_factory.cc.orig	2015-06-19 21:29:29 UTC
++++ media/video/capture/file_video_capture_device_factory.cc
+@@ -51,7 +51,7 @@
+       command_line_file_path.value(),
+       kFileVideoCaptureDeviceName,
+       VideoCaptureDevice::Name::AVFOUNDATION));
+-#elif defined(OS_LINUX)
++#elif defined(OS_LINUX) || defined(OS_BSD)
+   device_names->push_back(VideoCaptureDevice::Name(
+       command_line_file_path.value(),
+       kFileVideoCaptureDeviceName,

--- a/www/chromium/files/patch-media__video__capture__video_capture_device.cc
+++ b/www/chromium/files/patch-media__video__capture__video_capture_device.cc
@@ -1,0 +1,31 @@
+--- media/video/capture/video_capture_device.cc.orig	2015-06-19 21:26:28 UTC
++++ media/video/capture/video_capture_device.cc
+@@ -9,6 +9,10 @@
+ 
+ namespace media {
+ 
++const std::string VideoCaptureDevice::Name::GetModel() const {
++  return "";
++}
++
+ const std::string VideoCaptureDevice::Name::GetNameAndModel() const {
+   const std::string model_id = GetModel();
+   if (model_id.empty())
+@@ -24,7 +28,7 @@
+ VideoCaptureDevice::Name::Name(const std::string& name, const std::string& id)
+     : device_name_(name), unique_id_(id) {}
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ VideoCaptureDevice::Name::Name(const std::string& name,
+                                const std::string& id,
+                                const CaptureApiType api_type)
+@@ -69,7 +73,7 @@
+ 
+ VideoCaptureDevice::Name::~Name() {}
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ const char* VideoCaptureDevice::Name::GetCaptureApiTypeString() const {
+   switch (capture_api_type()) {
+     case V4L2_SINGLE_PLANE:

--- a/www/chromium/files/patch-media__video__capture__video_capture_device.h
+++ b/www/chromium/files/patch-media__video__capture__video_capture_device.h
@@ -1,0 +1,38 @@
+--- media/video/capture/video_capture_device.h.orig	2015-06-19 21:22:59 UTC
++++ media/video/capture/video_capture_device.h
+@@ -41,7 +41,7 @@
+     Name();
+     Name(const std::string& name, const std::string& id);
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+     // Linux/CrOS targets Capture Api type: it can only be set on construction.
+     enum CaptureApiType {
+       V4L2_SINGLE_PLANE,
+@@ -85,7 +85,7 @@
+ #endif
+ 
+ #if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX) || \
+-    defined(OS_ANDROID)
++    defined(OS_ANDROID) || defined(OS_BSD)
+     Name(const std::string& name, const std::string& id,
+          const CaptureApiType api_type);
+ #endif
+@@ -123,7 +123,7 @@
+     }
+ 
+ #if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX) || \
+-    defined(OS_ANDROID)
++    defined(OS_ANDROID) || defined(OS_BSD)
+     CaptureApiType capture_api_type() const {
+       return capture_api_class_.capture_api_type();
+     }
+@@ -155,7 +155,7 @@
+     std::string device_name_;
+     std::string unique_id_;
+ #if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX) || \
+-    defined(OS_ANDROID)
++    defined(OS_ANDROID) || defined(OS_BSD)
+     // This class wraps the CaptureApiType to give it a by default value if not
+     // initialized.
+     class CaptureApiClass {

--- a/www/chromium/files/patch-media__video__capture__video_capture_device_factory.cc
+++ b/www/chromium/files/patch-media__video__capture__video_capture_device_factory.cc
@@ -1,0 +1,21 @@
+--- media/video/capture/video_capture_device_factory.cc.orig	2015-06-19 21:33:03 UTC
++++ media/video/capture/video_capture_device_factory.cc
+@@ -14,6 +14,10 @@
+ // static
+ scoped_ptr<VideoCaptureDeviceFactory> VideoCaptureDeviceFactory::CreateFactory(
+     scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner) {
++#if defined(OS_BSD)
++  return scoped_ptr<VideoCaptureDeviceFactory>(new
++      media::FakeVideoCaptureDeviceFactory());
++#else
+   const base::CommandLine* command_line =
+       base::CommandLine::ForCurrentProcess();
+   // Use a Fake or File Video Device Factory if the command line flags are
+@@ -32,6 +36,7 @@
+     return scoped_ptr<VideoCaptureDeviceFactory>(
+         CreateVideoCaptureDeviceFactory(ui_task_runner));
+   }
++#endif
+ }
+ 
+ VideoCaptureDeviceFactory::VideoCaptureDeviceFactory() {


### PR DESCRIPTION
This seems to effectively disable support for video capture devices
(i.e. webcams) by using the FakeVideoCaptureDeviceFactory on BSD systems.

Tested only in DragonFly BSD's dports so far.