### PR TITLE
Fix segfault when stopping chromium.

### DIFF
--- a/www/chromium/files/patch-content__browser__time_zone_monitor_linux.cc
+++ b/www/chromium/files/patch-content__browser__time_zone_monitor_linux.cc
@@ -1,0 +1,22 @@
+--- content/browser/time_zone_monitor_linux.cc.orig	2015-05-25 19:00:26 UTC
++++ content/browser/time_zone_monitor_linux.cc
+@@ -51,6 +51,9 @@
+       : base::RefCountedThreadSafe<TimeZoneMonitorLinuxImpl>(),
+         file_path_watchers_(),
+         owner_(owner) {
++  }
++
++  void StartWatching() {
+     DCHECK_CURRENTLY_ON(BrowserThread::UI);
+     BrowserThread::PostTask(
+         BrowserThread::FILE,
+@@ -147,6 +150,9 @@
+   // changed.
+   if (!getenv("TZ")) {
+     impl_ = new TimeZoneMonitorLinuxImpl(this);
++    if (impl_.get()) {
++      impl_->StartWatching();
++    }
+   }
+ }
+ 


### PR DESCRIPTION
The TimeZoneMonitorLinuxImpl constructor (running on  the UI thread)
triggers a function to run on the FILE thread with PostTask. If that call
runs before the constructor is finished, it seems to destroy the
TimeZoneMonitorLinuxImpl object (because ref counting doesn't seem to be
correctly initialized yet, while the constructor isn't finished).
When chromium is terminated later, we try to destroy the already destroyed
TimeZoneMonitor causing a segfault.
I observed this problem on DragonFly, so I'm not sure if this actually
happens on FreeBSD.

This fix instead calls PostTask explicitly after constructing the TimeZoneMonitorLinuxImpl object.