### PR TITLE
Fix a segfault because of wrong sysctlbyname() usage.

### DIFF
--- a/www/chromium/files/patch-third_party__webrtc__base__systeminfo.cc
+++ b/www/chromium/files/patch-third_party__webrtc__base__systeminfo.cc
@@ -1,4 +1,4 @@
---- third_party/webrtc/base/systeminfo.cc.orig	2014-10-10 09:16:13 UTC
+--- third_party/webrtc/base/systeminfo.cc.orig	2015-06-11 20:19:52 UTC
 +++ third_party/webrtc/base/systeminfo.cc
 @@ -19,8 +19,12 @@
  #elif defined(WEBRTC_MAC) && !defined(WEBRTC_IOS)
@@ -23,19 +23,21 @@
  #include "webrtc/base/linux.h"
  #endif
  #include "webrtc/base/common.h"
-@@ -168,6 +172,17 @@
+@@ -168,6 +172,19 @@
    }
  #elif defined(__native_client__)
    // TODO(ryanpetrie): Implement this via PPAPI when it's available.
 +#elif defined(OS_FREEBSD)
-+  void* sysctl_value;
++  int sysctl_value;
 +  size_t length = sizeof(sysctl_value);
 +  if (!sysctlbyname("hw.ncpu", &sysctl_value, &length, NULL, 0)) {
-+    physical_cpus_ = *static_cast<int*>(sysctl_value);
++    physical_cpus_ = sysctl_value;
 +  }
++#if !defined(__DragonFly__)
 +  if (!sysctlbyname("kern.smp.cpus", &sysctl_value, &length, NULL, 0)) {
-+    logical_cpus_ = *static_cast<int*>(sysctl_value);
++    logical_cpus_ = sysctl_value;
 +  }
++#endif
 +  // L3 / L2 cache size?
 +  // CPU family/model/stepping (available in dmesg, kernel only TODO) 
  #else  // WEBRTC_LINUX


### PR DESCRIPTION
Also, kern.smp.cpus doesn't exist on DragonFly.
I'll need to dig out how to do the equivalent thing on DragonFly, to further improve this.