### PR TITLE
update to Chromium 46.0.2490.86

### DIFF
--- a/www/chromium/Makefile
+++ b/www/chromium/Makefile
@@ -1,8 +1,8 @@
 # Created by: Florent Thoumie <flz@FreeBSD.org>
-# $FreeBSD: head/www/chromium/Makefile 398035 2015-09-27 10:49:25Z rene $
+# $FreeBSD: head/www/chromium/Makefile 400136 2015-10-24 20:29:55Z rene $
 
 PORTNAME=	chromium
-PORTVERSION=	46.0.2490.80
+PORTVERSION=	46.0.2490.86
 CATEGORIES=	www
 MASTER_SITES=	http://commondatastorage.googleapis.com/chromium-browser-official/
 DISTFILES=	${DISTNAME}${EXTRACT_SUFX} # default, but needed to get distinfo correct if TEST is on

--- a/www/chromium/distinfo
+++ b/www/chromium/distinfo
@@ -1,4 +1,2 @@
-SHA256 (chromium-46.0.2490.80.tar.xz) = fe8610294664b44fdf80d9d0ed140158783474e7ae889e3a34ed32d24913fe3f
-SIZE (chromium-46.0.2490.80.tar.xz) = 342486988
-SHA256 (chromium-46.0.2490.80-testdata.tar.xz) = e578b77b50f8a1d4a53411f56beb8b59febd0c6e5747e6296e6b3365c47d165a
-SIZE (chromium-46.0.2490.80-testdata.tar.xz) = 116963720
+SHA256 (chromium-46.0.2490.86.tar.xz) = ee18d28ac80ff958e8a6c770bfc0d7d770b55452ed91a87f731e1b432a7d1d92
+SIZE (chromium-46.0.2490.86.tar.xz) = 356008056


### PR DESCRIPTION
Release Announcement:
http://googlechromereleases.blogspot.de/2015/11/stable-channel-update.html

Security: CVE-2015-1302 (possibly more)