### PR TITLE
Switch from devel/llvm39 to devel/llvm40.

### DIFF
--- a/www/chromium/Makefile
+++ b/www/chromium/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	chromium
 PORTVERSION=	58.0.3029.110
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	http://commondatastorage.googleapis.com/chromium-browser-official/
 DISTFILES=	${DISTNAME}${EXTRACT_SUFX} # default, but needed to get distinfo correct if TEST is on
@@ -14,7 +15,7 @@ LICENSE=	BSD3CLAUSE LGPL21 MPL
 LICENSE_COMB=	multi
 
 BUILD_DEPENDS=	gperf:devel/gperf \
-		clang39:devel/llvm39 \
+		clang40:devel/llvm40 \
 		yasm:devel/yasm \
 		python:lang/python \
 		ffmpeg>=3.2.2,1:multimedia/ffmpeg \
@@ -188,8 +189,8 @@ ALL_TARGET+=	${TEST_TARGETS}
 
 .include <bsd.port.pre.mk>
 
-CC=		clang39
-CXX=		clang++39
+CC=		clang40
+CXX=		clang++40
 #optionally set AR, LD, NM, READELF ?
 
 # TODO: -isystem, would be just as ugly as this approach, but more reliably

--- a/www/chromium/files/patch-build_toolchain_gcc__toolchain.gni
+++ b/www/chromium/files/patch-build_toolchain_gcc__toolchain.gni
@@ -21,12 +21,12 @@
 -    cxx = "$prefix/clang++"
 -    ld = cxx
 +    if (is_bsd) {
-+      cc = "${toolprefix}clang39"
-+      cxx = "${toolprefix}clang++39"
++      cc = "${toolprefix}clang40"
++      cxx = "${toolprefix}clang++40"
 +      ld = cxx
 +      readelf = "readelf"
-+      ar = "${toolprefix}llvm-ar39"
-+      nm = "${toolprefix}llvm-nm39"
++      ar = "${toolprefix}llvm-ar40"
++      nm = "${toolprefix}llvm-nm40"
 +    } else {
 +      prefix = rebase_path("$clang_base_path/bin", root_build_dir)
 +      cc = "$prefix/clang"


### PR DESCRIPTION
Move to the latest LLVM port in the tree. The port has been tested and runs
fine on 12-CURRENT.