### PR TITLE
Use openh264 system library to avoid the lld linker errors 'can't cre…

### DIFF
--- a/www/chromium/Makefile
+++ b/www/chromium/Makefile
@@ -49,6 +49,7 @@ LIB_DEPENDS=	libspeechd.so:accessibility/speech-dispatcher \
 		libpng.so:graphics/png \
 		libwebp.so:graphics/webp \
 		libavcodec.so:multimedia/ffmpeg \
+		libopenh264.so:multimedia/openh264 \
 		libcups.so:print/cups \
 		libfreetype.so:print/freetype2 \
 		libharfbuzz.so:print/harfbuzz \
@@ -247,7 +248,7 @@ pre-configure:
 	#./build/linux/unbundle/remove_bundled_libraries.py [list of preserved]
 	cd ${WRKSRC} && ${PYTHON_CMD} \
 		./build/linux/unbundle/replace_gn_files.py --system-libraries \
-		ffmpeg flac freetype harfbuzz-ng libdrm libwebp libxml libxslt opus snappy yasm || ${FALSE}
+		ffmpeg flac freetype harfbuzz-ng libdrm libwebp libxml libxslt openh264 opus snappy yasm || ${FALSE}
 .endif
 
 do-configure:


### PR DESCRIPTION
…ate dynamic relocation R_386_32 against local symbol in readonly segment' on i386