### PR TITLE
www/chromium: reintroduce patch for DIR_POLICY_FILES path.

### DIFF
--- a/www/chromium/Makefile
+++ b/www/chromium/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	chromium
 PORTVERSION=	79.0.3945.117
+PORTREVISION=	1
 CATEGORIES?=	www java
 MASTER_SITES=	https://commondatastorage.googleapis.com/chromium-browser-official/ \
 		LOCAL/cpm/chromium/:fonts

--- a/www/chromium/files/patch-chrome_common_chrome__paths.cc
+++ b/www/chromium/files/patch-chrome_common_chrome__paths.cc
@@ -35,6 +35,16 @@
        if (!GetUserDownloadsDirectorySafe(&cur))
          return false;
        break;
+@@ -482,6 +482,9 @@ bool PathProvider(int key, base::FilePath* result) {
+     case chrome::DIR_POLICY_FILES: {
+ #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+       cur = base::FilePath(FILE_PATH_LITERAL("/etc/opt/chrome/policies"));
++#elif defined(OS_BSD)
++      cur = base::FilePath(FILE_PATH_LITERAL(
++          "/usr/local/etc/chrome/policies"));
+ #else
+       cur = base::FilePath(FILE_PATH_LITERAL("/etc/chromium/policies"));
+ #endif
 @@ -502,7 +502,7 @@ bool PathProvider(int key, base::FilePath* result) {
      }
  #endif


### PR DESCRIPTION
This was accidentally removed in 9611a7ec68b750c5c43e38f7c97dc4691bdeae7a